### PR TITLE
fix: fixed a bug where public pages - e.g. /scoreboard were not being…

### DIFF
--- a/src/_App/config/client.js
+++ b/src/_App/config/client.js
@@ -33,7 +33,8 @@ const wsLink = new WebSocketLink(
     lazy: true,
     connectionParams: {
       headers: {
-        authorization: `Bearer ${localStorage.getItem('id_token') || ''}`,
+        ...(localStorage.getItem('id_token')
+          && { authorization: `Bearer ${localStorage.getItem('id_token')}` })
       },
     },
   }),
@@ -42,7 +43,8 @@ const wsLink = new WebSocketLink(
 const authLink = setContext((_, { headers }) => ({
   headers: {
     ...headers,
-    authorization: `Bearer ${localStorage.getItem('id_token') || ''}`,
+    ...(localStorage.getItem('id_token')
+      && { authorization: `Bearer ${localStorage.getItem('id_token')}` })
   },
 }))
 


### PR DESCRIPTION
… displayed because the authorization header had a null header instead of there not being an authorization header in the first place