### PR TITLE
fix: fixing an error where team_event is empty and throws an error be…

### DIFF
--- a/src/pages/Admin/Home/components/TeamsTab/index.js
+++ b/src/pages/Admin/Home/components/TeamsTab/index.js
@@ -158,6 +158,7 @@ const TeamsTab = () => {
     <React.Fragment>
       <FFAToggle ffaChecked={ffaChecked} handleFfaClick={handleFfaClick} />
       <div style={{ height: 'auto', width: '50%', margin: '0 auto' }}>
+        {data.team_event.length < 1 && null}
         {data.team_event.map(({ team }) => {
           if (team.submissionsByteamId_aggregate.aggregate.count < 1) {
             return null


### PR DESCRIPTION
…cause we check for the object that doesn't exist